### PR TITLE
업데이트 45 문구 대응

### DIFF
--- a/WebProject/app/Enum/EnumPatch.php
+++ b/WebProject/app/Enum/EnumPatch.php
@@ -8,14 +8,18 @@ namespace App\Enum;
 class EnumPatch
 {
     const NONE = 0;            // 이 상태이면 안됨. DB가 DEFAULT 값 넣은 것
+    const TEMP = 5;            // 급히 올릴 때 이름 대응 안되어 있을까봐
     // ... 중간 생략
     const UPDATE_45_PTS = 450; // update-45pts lang 파일
+    const UPDATE_45 = 455;     // update-45 lang 파일
 
     /**
      * patch 값을 사람이 읽을 수 있는 string 으로 변환합니다.
      */
     static array $patchName = array(
         self::NONE => 'None',
+        self::TEMP => '임시 파일',
         self::UPDATE_45_PTS => '45 PTS',
+        self::UPDATE_45 => '45',
     );
 }

--- a/WebProject/resources/views/download.blade.php
+++ b/WebProject/resources/views/download.blade.php
@@ -33,7 +33,7 @@
                         <tbody>
                         @foreach($patch_kr_link_group as $patchKrLink)
                             <tr>
-                                <td class="border border-gray-300 px-4 py-2">{{ EnumPatch::$patchName[$patchKrLink->patch] }}</td>
+                                <td class="border border-gray-300 px-4 py-2">{{ EnumPatch::$patchName[$patchKrLink->patch] ?? '알 수 없는 버전' }}</td>
                                 <td class="border border-gray-300 px-4 py-2">
                                     {{--                                    FIXME 왜 파란색으로 안나오는지 모르겠음 --}}
                                     <a href="{{ $patchKrLink->link }}" target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
업데이트 45 링크를 Download 페이지에 올리려고 하니 업데이트45 버전값으로 Enum 대응이 되어있지 않아 에러가 발생합니다. 간단히 스트링만 추가하고 해당 값이 없을 때 에러 대응합니다.