### PR TITLE
워크로드 조정

### DIFF
--- a/Environment/KubernetesValue/live/엘라스틱서치.yaml
+++ b/Environment/KubernetesValue/live/엘라스틱서치.yaml
@@ -6,11 +6,9 @@ spec:
   version: 8.17.3
   nodeSets:
     - name: default
-      count: 2
+      count: 1
       config:
         node.store.allow_mmap: false
-    - name: default
-      count: 3
       volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data # Do not change this name unless you set up a volume mount for the data path.

--- a/Environment/KubernetesValue/live/키바나.yaml
+++ b/Environment/KubernetesValue/live/키바나.yaml
@@ -4,6 +4,6 @@ metadata:
   name: quickstart
 spec:
   version: 8.17.3
-  count: 1
+  count: 0
   elasticsearchRef:
     name: quickstart


### PR DESCRIPTION
키바나 안쓸 때에는 파드 내려놓습니다. 수동으로 야믈 파일 replica 조정했더니 오퍼레이터가 복구시켜서 CR 자체에 씁니다. 엘라스틱서치 비용 문제로 2->1 조정합니다. 그리고 PUT /_settings
                              {
                                "index.number_of_replicas": 0
                              }
elasticsearch CR이 yellow 상태가 돼서 replica 갯수 1->0 으로 줄입니다.